### PR TITLE
Async image Rendering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,18 @@
 use anyhow::Result;
 use bresson::{state::*, ui::*};
 use globe::{CameraConfig, GlobeConfig, GlobeTemplate};
-use std::{path::Path, sync::mpsc};
+use ratatui_image::{protocol::StatefulProtocol, Resize};
+use std::{path::Path, sync::mpsc, thread, time::Duration};
 use tui::restore_terminal;
 
-use crossterm::event::{self, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{prelude::*, widgets::TableState};
 // use ratatui_image::picker::Picker;
+
+enum AppEvent {
+    KeyEvent(KeyEvent),
+    Redraw(Box<dyn StatefulProtocol>),
+}
 
 fn main() -> Result<()> {
     if std::env::args().len() < 2 {
@@ -27,9 +33,7 @@ fn main() -> Result<()> {
     };
 
     let image_file = Path::new(&image_arg);
-    if image_file.is_file() {
-        eprintln!("Image: {}\n", image_file.display());
-    } else {
+    if !image_file.is_file() {
         eprintln!("Image not present");
         return Ok(());
     }
@@ -39,14 +43,38 @@ fn main() -> Result<()> {
         .with_camera(CameraConfig::new(cam_zoom, 0., 0.))
         // .display_night(true)
         .build();
-    let mut app = Application::new(image_file, globe, app_mode)?;
-    let mut table_state = TableState::new().with_selected(Some(0));
 
-    // let (tx_main, rec_main) = mpsc::channel();
-    // let tx_main_render = tx_main.clone();
-    // thread::spawn(move || loop {
-    //     if let Ok((mut protocol, resize, area)) =
-    // })
+    // Send a [ResizeProtocol] to resize and encode it in a separate thread.
+    let (tx_worker, rec_worker) = mpsc::channel::<(Box<dyn StatefulProtocol>, Resize, Rect)>();
+
+    // Send UI-events and the [ResizeProtocol] result back to main thread.
+    let (tx_main, rec_main) = mpsc::channel();
+
+    // Resize and encode in background thread.
+    let tx_main_render = tx_main.clone();
+    thread::spawn(move || loop {
+        if let Ok((mut protocol, resize, area)) = rec_worker.recv() {
+            protocol.resize_encode(&resize, None, area);
+            tx_main_render.send(AppEvent::Redraw(protocol)).unwrap();
+        }
+    });
+    let mut app = Application::new(image_file, globe, app_mode, tx_worker)?;
+
+    // Poll events in background thread to demonstrate polling terminal events and redraw events
+    // concurrently. It's not required to do it this way - the "redraw event" from the channel
+    // could be read after polling the terminal events (as long as it's done with a timout). But
+    // then the rendering of the image will always be somewhat delayed.
+    let tx_main_events = tx_main.clone();
+    thread::spawn(move || -> Result<(), std::io::Error> {
+        loop {
+            if crossterm::event::poll(Duration::from_millis(16))? {
+                if let Event::Key(key) = event::read()? {
+                    tx_main_events.send(AppEvent::KeyEvent(key)).unwrap();
+                }
+            }
+        }
+    });
+    let mut table_state = TableState::new().with_selected(Some(0));
     match app.app_mode {
         AppMode::CommandLine => {
             // Print out the Exif Data in the CLI
@@ -68,97 +96,100 @@ fn main() -> Result<()> {
 
             loop {
                 terminal.draw(|frame| view(&mut app, frame, &mut table_state))?;
-                if event::poll(std::time::Duration::from_millis(16))? {
-                    if let event::Event::Key(key) = event::read()? {
-                        if key.kind == KeyEventKind::Press && !app.show_keybinds {
-                            match key.code {
-                                KeyCode::Char(c) => match c {
-                                    'o' | 'O' => {
-                                        // Show Original Data
-                                        app.modified_fields = app.original_fields.clone();
-                                        if app.has_gps && !app.should_rotate {
-                                            app.transform_coordinates();
-                                        }
-                                        app.show_message("Showing Original Data".to_owned());
-                                    }
-                                    'r' => {
-                                        // Only randomize the selected element based on table state
-                                        match table_state.selected() {
-                                            Some(index) => {
-                                                app.randomize(index);
+                if let Ok(ev) = rec_main.try_recv() {
+                    match ev {
+                        AppEvent::KeyEvent(key) => {
+                            if key.kind == KeyEventKind::Press && !app.show_keybinds {
+                                match key.code {
+                                    KeyCode::Char(c) => match c {
+                                        'o' | 'O' => {
+                                            // Show Original Data
+                                            app.modified_fields = app.original_fields.clone();
+                                            if app.has_gps && !app.should_rotate {
+                                                app.transform_coordinates();
                                             }
-                                            None => {}
+                                            app.show_message("Showing Original Data".to_owned());
                                         }
-                                    }
-                                    'R' => {
-                                        // Randomize all fields (generalize over the individual field)
-                                        app.randomize_all();
-                                        app.show_message("Randomized all".to_owned());
-                                    }
-                                    'c' | 'C' => {
-                                        app.clear_fields();
-                                        app.show_message("Cleared Metadata".to_owned())
-                                    }
-                                    's' | 'S' => {
-                                        // Save the state into a file copy
-                                        app.save_state()?;
-                                    }
-                                    '?' => {
-                                        // Display a popup window with keybinds
-                                        // toggle the show_keybinds state
-                                        app.toggle_keybinds();
-                                    }
-                                    'q' => break,
-                                    '+' => app.camera_zoom_increase(),
-                                    '-' => app.camera_zoom_decrease(),
-                                    ' ' => app.toggle_rotate(),
-                                    _ => {}
-                                },
-                                KeyCode::Esc => {
-                                    break;
-                                }
-                                KeyCode::Down => match table_state.selected() {
-                                    Some(i) => {
-                                        if i == app.modified_fields.len() - 1 {
-                                            *table_state.selected_mut() = Some(0)
-                                        } else {
-                                            *table_state.selected_mut() = Some(i + 1)
+                                        'r' => {
+                                            // Only randomize the selected element based on table state
+                                            match table_state.selected() {
+                                                Some(index) => {
+                                                    app.randomize(index);
+                                                }
+                                                None => {}
+                                            }
                                         }
+                                        'R' => {
+                                            // Randomize all fields (generalize over the individual field)
+                                            app.randomize_all();
+                                            app.show_message("Randomized all".to_owned());
+                                        }
+                                        'c' | 'C' => {
+                                            app.clear_fields();
+                                            app.show_message("Cleared Metadata".to_owned())
+                                        }
+                                        's' | 'S' => {
+                                            // Save the state into a file copy
+                                            app.save_state()?;
+                                        }
+                                        '?' => {
+                                            // Display a popup window with keybinds
+                                            // toggle the show_keybinds state
+                                            app.toggle_keybinds();
+                                        }
+                                        'q' => break,
+                                        '+' => app.camera_zoom_increase(),
+                                        '-' => app.camera_zoom_decrease(),
+                                        ' ' => app.toggle_rotate(),
+                                        _ => {}
+                                    },
+                                    KeyCode::Esc => {
+                                        break;
                                     }
-                                    None => *table_state.selected_mut() = Some(0),
-                                },
-                                KeyCode::Up => match table_state.selected() {
-                                    Some(i) => {
-                                        if i == 0 {
+                                    KeyCode::Down => match table_state.selected() {
+                                        Some(i) => {
+                                            if i == app.modified_fields.len() - 1 {
+                                                *table_state.selected_mut() = Some(0)
+                                            } else {
+                                                *table_state.selected_mut() = Some(i + 1)
+                                            }
+                                        }
+                                        None => *table_state.selected_mut() = Some(0),
+                                    },
+                                    KeyCode::Up => match table_state.selected() {
+                                        Some(i) => {
+                                            if i == 0 {
+                                                *table_state.selected_mut() =
+                                                    Some(app.modified_fields.len() - 1)
+                                            } else {
+                                                *table_state.selected_mut() = Some(i - 1)
+                                            }
+                                        }
+                                        None => {
                                             *table_state.selected_mut() =
                                                 Some(app.modified_fields.len() - 1)
-                                        } else {
-                                            *table_state.selected_mut() = Some(i - 1)
                                         }
-                                    }
-                                    None => {
-                                        *table_state.selected_mut() =
-                                            Some(app.modified_fields.len() - 1)
-                                    }
-                                },
-                                _ => {}
-                            }
-                        } else {
-                            match key.code {
-                                KeyCode::Char(c) => match c {
-                                    '?' => {
-                                        // Display a popup window with keybinds
-                                        // toggle the show_keybinds state
+                                    },
+                                    _ => {}
+                                }
+                            } else {
+                                match key.code {
+                                    KeyCode::Char(c) => match c {
+                                        '?' => {
+                                            // Display a popup window with keybinds
+                                            // toggle the show_keybinds state
+                                            app.toggle_keybinds();
+                                        }
+                                        _ => {}
+                                    },
+                                    KeyCode::Esc => {
                                         app.toggle_keybinds();
                                     }
                                     _ => {}
-                                },
-                                KeyCode::Esc => {
-                                    app.toggle_keybinds();
                                 }
-                                _ => {}
                             }
                         }
+                        AppEvent::Redraw(protocol) => app.async_state.inner = Some(protocol),
                     }
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bresson::{state::*, ui::*};
 use globe::{CameraConfig, GlobeConfig, GlobeTemplate};
-use std::path::Path;
+use std::{path::Path, sync::mpsc};
 use tui::restore_terminal;
 
 use crossterm::event::{self, KeyCode, KeyEventKind};
@@ -42,6 +42,11 @@ fn main() -> Result<()> {
     let mut app = Application::new(image_file, globe, app_mode)?;
     let mut table_state = TableState::new().with_selected(Some(0));
 
+    // let (tx_main, rec_main) = mpsc::channel();
+    // let tx_main_render = tx_main.clone();
+    // thread::spawn(move || loop {
+    //     if let Ok((mut protocol, resize, area)) =
+    // })
     match app.app_mode {
         AppMode::CommandLine => {
             // Print out the Exif Data in the CLI

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ fn main() -> Result<()> {
                                             // Save the state into a file copy
                                             app.save_state()?;
                                         }
+                                        't' | 'T' => app.toggle_render_state(),
                                         '?' => {
                                             // Display a popup window with keybinds
                                             // toggle the show_keybinds state

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,19 +1,21 @@
-use crate::utils::floyd_steinberg;
 use anyhow::Result;
 use chrono::prelude::*;
 use core::f32;
 use exif::{experimental::Writer, Exif, Field, In, Rational, SRational, Tag, Value};
 use globe::Globe;
+use image::Rgb;
 use rand::{rngs::ThreadRng, seq::SliceRandom, Rng};
-use ratatui::widgets::Row;
-use ratatui_image::{
-    picker::Picker,
-    protocol::{ImageSource, Protocol, StatefulProtocol},
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    widgets::{Row, StatefulWidget},
 };
+use ratatui_image::{picker::Picker, protocol::StatefulProtocol, Resize};
 use std::{
     collections::HashSet,
     io::{self, Read, Write},
     path::{Path, PathBuf},
+    sync::mpsc::{self, Sender},
 };
 
 // Step one is taking a given image file and read out some of the super basic metadata about it
@@ -65,6 +67,46 @@ impl Default for GPSInfo {
 
 pub type ExifTags = Vec<Field>;
 
+/// A widget that uses a custom ThreadProtocol as state to offload resizing and encoding
+/// to a background thread
+pub struct ThreadImage {
+    pub resize: Resize,
+}
+
+impl ThreadImage {
+    pub fn new() -> ThreadImage {
+        ThreadImage {
+            resize: Resize::Fit,
+        }
+    }
+
+    pub fn resize(mut self, resize: Resize) -> ThreadImage {
+        self.resize = resize;
+        self
+    }
+}
+
+/// The state of a ThreadImage.
+///
+/// Has `inner` [ResizeProtocol] that is sent off to the `tx` mspc channel to do the
+/// `resize_encode()` work.
+pub struct ThreadProtocol {
+    pub inner: Option<Box<dyn StatefulProtocol>>,
+    pub tx: Sender<(Box<dyn StatefulProtocol>, Resize, Rect)>,
+}
+
+impl ThreadProtocol {
+    pub fn new(
+        tx: Sender<(Box<dyn StatefulProtocol>, Resize, Rect)>,
+        inner: Box<dyn StatefulProtocol>,
+    ) -> ThreadProtocol {
+        ThreadProtocol {
+            inner: Some(inner),
+            tx,
+        }
+    }
+}
+
 pub struct Application {
     pub path_to_image: PathBuf,
     // pub image_source: ImageSource,
@@ -73,6 +115,8 @@ pub struct Application {
     pub original_fields: ExifTags,
     pub modified_fields: ExifTags,
     pub tags_to_randomize: HashSet<Tag>,
+
+    pub async_state: ThreadProtocol,
 
     pub status_msg: String,
 
@@ -109,16 +153,17 @@ impl Application {
         let exifreader = exif::Reader::new();
         let exif = exifreader.read_from_container(&mut bufreader)?;
         let mut has_gps = false;
+        let mut picker = Picker::from_termios().unwrap();
+        picker.guess_protocol();
+        picker.background_color = Some(Rgb::<u8>([255, 0, 255]));
 
-        // let dyn_img = image::io::Reader::open(path_to_image)?.decode()?;
+        let dyn_img = image::io::Reader::open(path_to_image)?.decode()?;
 
-        // let mut picker = Picker::new((8, 12));
-        // let mut picker = Picker::from_termios().unwrap();
-        // picker.guess_protocol();
-        // dyn_img = floyd_steinberg(dyn_img);
+        // Send a [ResizeProtocol] to resize and encode it in a separate thread
+        let (tx_worker, rec_worker) = mpsc::channel::<(Box<dyn StatefulProtocol>, Resize, Rect)>();
+
         //
         // let image_source = ImageSource::new(dyn_img.clone(), picker.font_size);
-
         // let image = picker.new_resize_protocol(dyn_img);
 
         let tags_to_randomize = HashSet::from([
@@ -226,6 +271,7 @@ impl Application {
             original_fields: exif_data_rows.clone(),
             modified_fields: exif_data_rows.clone(),
             tags_to_randomize,
+            async_state: ThreadProtocol::new(tx_worker, picker.new_resize_protocol(dyn_img)),
             status_msg: String::new(),
             globe: g,
             app_mode,

--- a/src/state.rs
+++ b/src/state.rs
@@ -24,8 +24,8 @@ pub enum AppMode {
 
 #[derive(Debug, Clone, Copy)]
 pub enum RenderState {
-    Normal,
-    Help,
+    Thumbnail,
+    Globe,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -111,6 +111,7 @@ pub struct Application {
     pub tags_to_randomize: HashSet<Tag>,
 
     pub async_state: ThreadProtocol,
+    pub render_state: RenderState,
 
     pub status_msg: String,
 
@@ -257,13 +258,12 @@ impl Application {
 
         Ok(Self {
             path_to_image: path_to_image.to_path_buf(),
-            // image_source,
-            // image_static: image,
             exif,
             original_fields: exif_data_rows.clone(),
             modified_fields: exif_data_rows.clone(),
             tags_to_randomize,
             async_state: ThreadProtocol::new(tx_worker, picker.new_resize_protocol(dyn_img)),
+            render_state: RenderState::Globe,
             status_msg: String::new(),
             globe: g,
             app_mode,
@@ -709,6 +709,13 @@ impl Application {
 
     pub fn toggle_keybinds(&mut self) {
         self.show_keybinds = !self.show_keybinds;
+    }
+
+    pub fn toggle_render_state(&mut self) {
+        match self.render_state {
+            RenderState::Globe => self.render_state = RenderState::Thumbnail,
+            RenderState::Thumbnail => self.render_state = RenderState::Globe,
+        }
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,17 +5,13 @@ use exif::{experimental::Writer, Exif, Field, In, Rational, SRational, Tag, Valu
 use globe::Globe;
 use image::Rgb;
 use rand::{rngs::ThreadRng, seq::SliceRandom, Rng};
-use ratatui::{
-    buffer::Buffer,
-    layout::Rect,
-    widgets::{Row, StatefulWidget},
-};
+use ratatui::{layout::Rect, widgets::Row};
 use ratatui_image::{picker::Picker, protocol::StatefulProtocol, Resize};
 use std::{
     collections::HashSet,
     io::{self, Read, Write},
     path::{Path, PathBuf},
-    sync::mpsc::{self, Sender},
+    sync::mpsc::Sender,
 };
 
 // Step one is taking a given image file and read out some of the super basic metadata about it
@@ -109,8 +105,6 @@ impl ThreadProtocol {
 
 pub struct Application {
     pub path_to_image: PathBuf,
-    // pub image_source: ImageSource,
-    // pub image_static: Box<dyn StatefulProtocol>,
     pub exif: Exif,
     pub original_fields: ExifTags,
     pub modified_fields: ExifTags,
@@ -145,7 +139,12 @@ pub fn random_datetime(rng: &mut ThreadRng) -> String {
 }
 
 impl Application {
-    pub fn new(path_to_image: &Path, g: Globe, app_mode: AppMode) -> Result<Self> {
+    pub fn new(
+        path_to_image: &Path,
+        g: Globe,
+        app_mode: AppMode,
+        tx_worker: Sender<(Box<dyn StatefulProtocol>, Resize, Rect)>,
+    ) -> Result<Self> {
         let file = std::fs::File::open(path_to_image)?;
         // println!("Size of img is {}", file.metadata()?.len());
 
@@ -158,13 +157,6 @@ impl Application {
         picker.background_color = Some(Rgb::<u8>([255, 0, 255]));
 
         let dyn_img = image::io::Reader::open(path_to_image)?.decode()?;
-
-        // Send a [ResizeProtocol] to resize and encode it in a separate thread
-        let (tx_worker, rec_worker) = mpsc::channel::<(Box<dyn StatefulProtocol>, Resize, Rect)>();
-
-        //
-        // let image_source = ImageSource::new(dyn_img.clone(), picker.font_size);
-        // let image = picker.new_resize_protocol(dyn_img);
 
         let tags_to_randomize = HashSet::from([
             Tag::Make,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
     },
     Frame,
 };
-use ratatui_image::{Image, Resize, StatefulImage};
+use ratatui_image::Resize;
 
 fn render_metadata_table(
     app: &mut Application,
@@ -182,8 +182,8 @@ pub fn view(app: &mut Application, frame: &mut Frame, table_state: &mut TableSta
         .split(frame.size());
 
     render_metadata_table(app, frame, table_state, layout[0]);
-    render_globe(app, frame, layout[1]);
-    // render_image(app, frame, layout[1]);
+    // render_globe(app, frame, layout[1]);
+    render_image(app, frame, layout[1]);
     render_status_msg(app, frame, layout[2]);
 
     if app.show_keybinds {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -182,8 +182,11 @@ pub fn view(app: &mut Application, frame: &mut Frame, table_state: &mut TableSta
         .split(frame.size());
 
     render_metadata_table(app, frame, table_state, layout[0]);
-    // render_globe(app, frame, layout[1]);
-    render_image(app, frame, layout[1]);
+
+    match app.render_state {
+        RenderState::Thumbnail => render_image(app, frame, layout[1]),
+        RenderState::Globe => render_globe(app, frame, layout[1]),
+    }
     render_status_msg(app, frame, layout[2]);
 
     if app.show_keybinds {


### PR DESCRIPTION
This PR uses `ratatui_image` to add support for rendering the given image inside the program.

The image rendering and re-drawing is handled asynchronously in the background thread so it doesn't impact the performance of the UI.

PR also adds a new keybind - `t | T` to swap between showing the Globe and the Thumbnail.